### PR TITLE
Adding few steps to check Kernel version of Windows host

### DIFF
--- a/virtualization/windowscontainers/troubleshooting.md
+++ b/virtualization/windowscontainers/troubleshooting.md
@@ -94,3 +94,15 @@ Get-WinEvent -LogName Microsoft-Windows-Hyper-V-Compute-Admin
 Get-WinEvent -LogName Microsoft-Windows-Hyper-V-Compute-Operational 
 ```
 
+### Verifying Host Kernel Version
+Older Kernel is not supported to run Docker engine.  Following command will give you the kernel build of Windows host.
+```
+$(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion' BuildLabEx).BuildLabEx
+```
+Below is the example from Octorber 2017 update.
+```
+14393.1480.amd64fre.rs1_release.170706-2004
+```
+
+
+


### PR DESCRIPTION
We got a case where customer was attempting to install engine on older Kernel and had a hard time. These steps should help you manually check that. 